### PR TITLE
support tooltips on property

### DIFF
--- a/widget/array-prop/array-prop.html
+++ b/widget/array-prop/array-prop.html
@@ -2,7 +2,10 @@
     <link rel="import" type="css" href="array-prop.css">
 
     <template>
-        <div id="mainProp" class="layout horizontal center-center">
+        <div id="mainProp"
+            class="layout horizontal center-center"
+            title$="{{prop.attrs.tooltip}}"
+            >
             <i id="foldIcon"
                 class$="[[_foldClass(folded)]]"
                 on-mousedown="_onFoldMouseDown"

--- a/widget/object-prop/object-prop.html
+++ b/widget/object-prop/object-prop.html
@@ -2,7 +2,10 @@
     <link rel="import" type="css" href="object-prop.css">
 
     <template>
-        <div id="mainProp" class="layout horizontal center-center">
+        <div id="mainProp"
+            class="layout horizontal center-center"
+            title$="{{prop.attrs.tooltip}}"
+            >
             <i id="foldIcon"
                 class$="[[_foldClass(folded)]]"
                 on-mousedown="_onFoldMouseDown"

--- a/widget/value-prop/value-prop.html
+++ b/widget/value-prop/value-prop.html
@@ -4,7 +4,10 @@
     <link rel="import" type="css" href="value-prop.css">
 
     <template>
-        <div class="layout horizontal flex-1 group" readonly$="{{prop.attrs.readonly}}">
+        <div class="layout horizontal flex-1 group"
+            readonly$="{{prop.attrs.readonly}}"
+            title$="{{prop.attrs.tooltip}}"
+            >
             <div class$="{{_nameClass(prop.name,prop.attrs)}}"
                 on-mousedown="_onMouseDown"
                 >{{_nameText(prop.name,prop.attrs)}}</div>


### PR DESCRIPTION
效果(鼠标指针截图不了):
![image](https://cloud.githubusercontent.com/assets/1503156/11521434/15911d84-98e7-11e5-8f15-4a3d30df057b.png)
@jwu please review

关联 issue: https://github.com/fireball-x/fireball/issues/136, 这个 issue 主要说的是自带类型的文档提示，但用户提示还是需要这样来做。
